### PR TITLE
Fix curl cookiejar urlencode and expires. Write tests for CookieFile.

### DIFF
--- a/test/suites/CookieFileTest.php
+++ b/test/suites/CookieFileTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @license see LICENSE
+ */
+namespace Serps\Test\HttpClient;
+
+use Serps\Core\Cookie\Cookie;
+use Serps\HttpClient\CurlClient\CookieFile;
+
+/**
+ * @covers Serps\HttpClient\CurlClient\CookieFile
+ */
+class CookieFileTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider curlSerializedCookiesDataProvider
+     *
+     * @param Cookie[] $cookies
+     * @param string   $cookieStr
+     */
+    public function testCookieFileGenerate(array $cookies, $cookieStr)
+    {
+        $this->assertEquals($cookieStr, CookieFile::generate($cookies));
+    }
+
+    /**
+     * @dataProvider curlSerializedCookiesDataProvider
+     *
+     * @param Cookie[] $cookies
+     * @param string   $cookieStr
+     */
+    public function testCookieFileParse(array $cookies, $cookieStr)
+    {
+        $this->assertEquals($cookies, CookieFile::parse($cookieStr));
+    }
+
+    public function curlSerializedCookiesDataProvider()
+    {
+        return [
+            [
+                [
+                    new Cookie('test1', 'value1', [
+                        'domain'    => 'example.org',
+                        'path'      => '/',
+                        'secure'    => true,
+                        'expires'   => 1468951248,
+                        'http_only' => true
+                    ])
+                ],
+                "#HttpOnly_example.org\tFALSE\t/\tTRUE\t1468951248\ttest1\tvalue1"
+            ],
+            [
+                [
+                    new Cookie('test2', "\t#$%^&!-+=/\\;\t", [
+                        'domain'    => '.a.b.c.d.example.org',
+                        'path'      => '/a/b/c/d;e',
+                        'secure'    => true,
+                        'expires'   => 1468951248,
+                        'http_only' => false
+                    ])
+                ],
+                ".a.b.c.d.example.org\tTRUE\t/a/b/c/d;e\tTRUE\t1468951248\ttest2\t%09%23%24%25%5E%26%21-%2B%3D%2F%5C%3B%09"
+            ],
+        ];
+    }
+}

--- a/test/suites/CurlClientTest.php
+++ b/test/suites/CurlClientTest.php
@@ -4,13 +4,7 @@
  */
 namespace Serps\Test\HttpClient;
 
-use Psr\Http\Message\ResponseInterface;
-use Serps\Core\Cookie\ArrayCookieJar;
-use Serps\Core\Cookie\Cookie;
-use Serps\Core\Http\HttpClientInterface;
 use Serps\Core\Http\Proxy;
-use Serps\Core\Http\SearchEngineResponse;
-use Serps\HttpClient\CurlClient\CookieFile;
 use Serps\HttpClient\CurlClient;
 use Zend\Diactoros\Request;
 


### PR DESCRIPTION
Cookie value in CURL's jar should be urlencoded.
expireS - lost 's'

Issue #7 done
