### PR TITLE
fix of POST requests

### DIFF
--- a/src/CurlClient/Curl.php
+++ b/src/CurlClient/Curl.php
@@ -123,6 +123,8 @@ class Curl
         }
         if ($request->getMethod() === 'HEAD') {
             $options[CURLOPT_NOBODY] = true;
+        } elseif ($request->getMethod() === 'POST') {
+            $options[CURLOPT_POST] = true;
         } elseif ($request->getMethod() !== 'GET') {
             // GET is a default method. Other methods should be specified explicitly.
             $options[CURLOPT_CUSTOMREQUEST] = $request->getMethod();


### PR DESCRIPTION
The POST should be with the CURLOPT_POST option, because CURLOPT_CUSTOMREQUEST does not switch to GET after a 3XX redirect.